### PR TITLE
Optimise result fetching to aggregate sql side

### DIFF
--- a/Tests/HiveMime.Tests/Helpers/TestWebApplicationFactory.cs
+++ b/Tests/HiveMime.Tests/Helpers/TestWebApplicationFactory.cs
@@ -2,6 +2,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.AspNetCore.Mvc.Testing;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace HiveMime.Tests;
 
@@ -19,16 +20,11 @@ public class TestWebApplicationFactory : WebApplicationFactory<Program>
         builder.ConfigureServices(services =>
         {
             // Remove the existing DbContext registration
-            var descriptor = services.SingleOrDefault(
-                d => d.ServiceType == typeof(DbContextOptions<HiveMimeContext>));
-            if (descriptor != null)
-            {
-                services.Remove(descriptor);
-            }
+            var descriptor = services.RemoveAll<DbContextOptions<HiveMimeContext>>();
 
             // Register DbContext with Testcontainers connection string
-            services.AddDbContext<HiveMimeContext>(options =>
-                options.UseNpgsql(_connectionString));
+            services.AddDbContextFactory<HiveMimeContext>(options =>
+                options.UseNpgsql(_connectionString), ServiceLifetime.Scoped);
         });
     }
 }

--- a/Tests/HiveMime.Tests/PostServiceTests.cs
+++ b/Tests/HiveMime.Tests/PostServiceTests.cs
@@ -1,4 +1,3 @@
-using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 
 namespace HiveMime.Tests;
@@ -9,6 +8,7 @@ public class PostServiceTests : IntegrationTest
     private Post _defaultPost;
     private Post _defaultPost2;
     private Post _scorePost;
+    private Post _categoryPost;
     private User _defaultUser;
     private User _defaultUser2;
 
@@ -48,10 +48,7 @@ public class PostServiceTests : IntegrationTest
         var result = await _service.BrowsePostsAsync(null, null, null, null);
 
         // Assert
-        Assert.Equal(2, result.Count);
-
-        Assert.Equal(_defaultPost.Id, result[1].Id);
-        Assert.Equal(_defaultPost2.Id, result[0].Id);
+        Assert.Equal(4, result.Count);
     }
 
     [Fact]
@@ -72,10 +69,7 @@ public class PostServiceTests : IntegrationTest
         var result = await _service.BrowsePostsAsync(null, null, null, newPost.CreatedAt);
 
         // Assert
-        Assert.Equal(2, result.Count);
-
-        Assert.Equal(_defaultPost.Id, result[1].Id);
-        Assert.Equal(_defaultPost2.Id, result[0].Id);
+        Assert.Equal(4, result.Count);
     }
 
     [Fact]
@@ -131,12 +125,9 @@ public class PostServiceTests : IntegrationTest
     }
 
     [Fact]
-    public async Task GetPostResultAsync_WithManyScoreVotes_AggregatesCorrectly()
+    public async Task GetPostResultAsync_WithScoreVotes_AggregatesCorrectly()
     {
         // Arrange
-        Context.Posts.Add(_scorePost);
-        await Context.SaveChangesAsync();
-        
         var candidate = _scorePost.Polls[0].Candidates[0];
 
         // Add votes across the range
@@ -146,19 +137,45 @@ public class PostServiceTests : IntegrationTest
         var result = await _service.GetPostResultAsync(_scorePost.Id, "");
 
         // Assert
-        Assert.Equal(50, result.Polls[0].Candidates[0].Score);
+        Assert.Equal(50, result.Polls[0].Candidates[0].AverageScore);
         Assert.Equal(10, result.Polls[0].Candidates[0].VoterAmount);
-        Assert.Equal(0, result.Polls[1].Candidates[0].Score);
+        Assert.Equal(null, result.Polls[1].Candidates[0].AverageScore);
         Assert.Equal(0, result.Polls[1].Candidates[0].VoterAmount);
+    }
+
+    [Fact]
+    public async Task GetPostResultAsync_WithCategoryVotes_AggregatesCorrectly()
+    {
+        // Arrange
+        await AddVotesToCandidate(_categoryPost.Polls[0].Candidates[0].Id, _categoryPost.Id, [0, 0, 0, 0, 0, 0, 1, 1, 1, 1]);
+
+        // Act
+        var result = await _service.GetPostResultAsync(_categoryPost.Id, "");
+
+        // Assert
+        Assert.Equal(0, result.Polls[0].Candidates[0].MajorityVote);
+        Assert.Equal(0.6, result.Polls[0].Candidates[0].MajorityRatio.Value, 4);
+    }
+
+    [Fact]
+    public async Task GetPostResultAsync_WithChoiceVotes_AggregatesCorrectly()
+    {
+        // Arrange
+        await AddVotesToCandidate(_defaultPost.Polls[0].Candidates[0].Id, _defaultPost.Id, [1, 1, 1, 1]);
+        await AddVotesToCandidate(_defaultPost.Polls[0].Candidates[1].Id, _defaultPost.Id, [1, 1]);
+
+        // Act
+        var result = await _service.GetPostResultAsync(_defaultPost.Id, "");
+
+        // Assert
+        Assert.Equal(4, result.Polls[0].Candidates[0].VoterAmount);
+        Assert.Equal(2, result.Polls[0].Candidates[1].VoterAmount);
     }
 
     [Fact]
     public async Task GetCandidateDistributionResultsAsync_ScoreWithLargeRange_BucketsValues()
     {
         // Arrange
-        Context.Posts.Add(_scorePost);
-        await Context.SaveChangesAsync();
-        
         var candidate = _scorePost.Polls[0].Candidates[0];
 
         // Add votes across the range
@@ -176,9 +193,6 @@ public class PostServiceTests : IntegrationTest
     public async Task GetCandidateDistributionResultsAsync_ScoreWithSmallRange_NoBucketing()
     {
         // Arrange
-        Context.Posts.Add(_scorePost);
-        await Context.SaveChangesAsync();
-        
         var candidate = _scorePost.Polls[1].Candidates[0]; // Use small range score poll
 
         // Add votes
@@ -211,9 +225,6 @@ public class PostServiceTests : IntegrationTest
     public async Task GetCandidateDistributionResultsAsync_OrderedByKey_ReturnsInOrder()
     {
         // Arrange
-        Context.Posts.Add(_scorePost);
-        await Context.SaveChangesAsync();
-        
         var candidate = _scorePost.Polls[1].Candidates[0]; // Use small range score poll
         
         // Add votes in random order
@@ -316,7 +327,7 @@ public class PostServiceTests : IntegrationTest
         {
             Title = "Score Post",
             Description = "This is a score post with large range.",
-            Creator = _defaultUser,
+            Creator = _defaultUser2,
             Polls = [
                 new Poll
                 {
@@ -345,7 +356,33 @@ public class PostServiceTests : IntegrationTest
             ]
         };
 
+        _categoryPost = new()
+        {
+            Creator = _defaultUser2,
+            Polls = [
+                new Poll
+                {
+                    Title = "Category Poll",
+                    Description = "This is a category poll.",
+                    PollType = PollType.Category,
+                    MinValue = 1,
+                    MaxValue = 2,
+                    Candidates = new List<Candidate>
+                    {
+                        new Candidate { Name = "A" }
+                    },
+                    Categories = new List<Category>
+                    {
+                        new Category { Name = "Category 1" },
+                        new Category { Name = "Category 2" }
+                    }
+                }
+            ]
+        };
+
         Context.Posts.Add(_defaultPost);
         Context.Posts.Add(_defaultPost2);
+        Context.Posts.Add(_scorePost);
+        Context.Posts.Add(_categoryPost);
     }
 }

--- a/Tests/HiveMime.Tests/PostServiceTests.cs
+++ b/Tests/HiveMime.Tests/PostServiceTests.cs
@@ -131,6 +131,28 @@ public class PostServiceTests : IntegrationTest
     }
 
     [Fact]
+    public async Task GetPostResultAsync_WithManyScoreVotes_AggregatesCorrectly()
+    {
+        // Arrange
+        Context.Posts.Add(_scorePost);
+        await Context.SaveChangesAsync();
+        
+        var candidate = _scorePost.Polls[0].Candidates[0];
+
+        // Add votes across the range
+        await AddVotesToCandidate(candidate.Id, _scorePost.Id, [5, 15, 25, 35, 45, 55, 65, 75, 85, 95]);
+
+        // Act
+        var result = await _service.GetPostResultAsync(_scorePost.Id, "");
+
+        // Assert
+        Assert.Equal(50, result.Polls[0].Candidates[0].Score);
+        Assert.Equal(10, result.Polls[0].Candidates[0].VoterAmount);
+        Assert.Equal(0, result.Polls[1].Candidates[0].Score);
+        Assert.Equal(0, result.Polls[1].Candidates[0].VoterAmount);
+    }
+
+    [Fact]
     public async Task GetCandidateDistributionResultsAsync_ScoreWithLargeRange_BucketsValues()
     {
         // Arrange

--- a/src/Dtos/Post/PostResultDto.cs
+++ b/src/Dtos/Post/PostResultDto.cs
@@ -11,7 +11,9 @@ public class PollResultDto
 public class PollCandidateResultDto : CandidateDto
 {
     public int VoterAmount { get; set; }
-    public double Score { get; set; }
+    public double? AverageScore { get; set; }
+    public int? MajorityVote { get; set; }
+    public double? MajorityRatio { get; set; }
 }
 
 public class CandidateResultDto

--- a/src/Dtos/Post/PostResultDto.cs
+++ b/src/Dtos/Post/PostResultDto.cs
@@ -24,5 +24,6 @@ public class CandidateResultDto
 
 public class CandidateDistributionDto
 {
+    public int Value { get; set; }
     public int Score { get; set; }
 }

--- a/src/Dtos/Post/PostResultDto.cs
+++ b/src/Dtos/Post/PostResultDto.cs
@@ -11,7 +11,7 @@ public class PollResultDto
 public class PollCandidateResultDto : CandidateDto
 {
     public int VoterAmount { get; set; }
-    public int Score { get; set; }
+    public double Score { get; set; }
 }
 
 public class CandidateResultDto

--- a/src/Helpers/MapsterConfiguration.cs
+++ b/src/Helpers/MapsterConfiguration.cs
@@ -8,7 +8,6 @@ public static class MapsterConfiguration
     {
         ConfigurePost();
         ConfigureComment();
-        ConfigureCandidate();
         ConfigureHive();
     }
 
@@ -17,13 +16,6 @@ public static class MapsterConfiguration
         _config.NewConfig<Post, PostDto>()
             .Map(dest => dest.CommentCount, src => src.Comments.Count(c => c.ParentCommentId == null))
             .Map(dest => dest.VoteCount, src => src.PostVotes.Count);
-    }
-
-    private static void ConfigureCandidate()
-    {
-        _config.NewConfig<Candidate, PollCandidateResultDto>()
-            .Map(dest => dest.VoterAmount, src => src.Votes.Count)
-            .Map(dest => dest.Score, src => src.Votes.Sum(vote => vote.Value));
     }
 
     private static void ConfigureComment()

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -26,7 +26,7 @@ public class Program
             .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
         services.AddDbContextFactory<HiveMimeContext>(options =>
-            options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")), ServiceLifetime.Scoped);
+            options.UseNpgsql(builder.Configuration.GetConnectionString("TestConnection")), ServiceLifetime.Scoped);
         services.AddScoped(s => s.GetService<IDbContextFactory<HiveMimeContext>>().CreateDbContext());
 
         services.AddAuthentication("Bearer")

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -25,8 +25,9 @@ public class Program
             .AddMvcOptions(o => o.Filters.Add(new AuthorizeFilter()))
             .AddJsonOptions(options => options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter()));
 
-        services.AddDbContext<HiveMimeContext>(options =>
-            options.UseNpgsql(builder.Configuration.GetConnectionString("TestConnection")));
+        services.AddDbContextFactory<HiveMimeContext>(options =>
+            options.UseNpgsql(builder.Configuration.GetConnectionString("DefaultConnection")), ServiceLifetime.Scoped);
+        services.AddScoped(s => s.GetService<IDbContextFactory<HiveMimeContext>>().CreateDbContext());
 
         services.AddAuthentication("Bearer")
             .AddJwtBearer("Bearer", options =>

--- a/src/Program.cs
+++ b/src/Program.cs
@@ -120,7 +120,7 @@ public class Program
         {
             // During development, reset the databse on restart.
             var db = scope.ServiceProvider.GetRequiredService<HiveMimeContext>();
-            db.Database.EnsureDeleted();
+            //db.Database.EnsureDeleted();
             db.Database.EnsureCreated();
         }
     }

--- a/src/Services/PostService.cs
+++ b/src/Services/PostService.cs
@@ -159,17 +159,18 @@ public class PostService(HiveMimeContext context)
         {
             // Bucket up the votes for score polls because of the large amount of possible values.
             int stepValue = (int)Math.Ceiling((candidateInfo.MaxValue - candidateInfo.MinValue + 1) / 10.0);
-            distributionQuery = filteredVotes.GroupBy(v => (v.Value - candidateInfo.MinValue) / stepValue);
+            distributionQuery = filteredVotes.GroupBy(v => ((v.Value - candidateInfo.MinValue) / stepValue) * stepValue + candidateInfo.MinValue);
         }
         else
         {
-             distributionQuery = filteredVotes.GroupBy(v => v.Value);        
+            distributionQuery = filteredVotes.GroupBy(v => v.Value);        
         }
 
         return await distributionQuery
             .OrderBy(g => g.Key)
             .Select(g => new CandidateDistributionDto
             {
+                Value = g.Key,
                 Score = g.Count(),
             })
             .ToListAsync();

--- a/src/Services/PostService.cs
+++ b/src/Services/PostService.cs
@@ -111,16 +111,8 @@ public class PostService(HiveMimeContext context)
             .Where(v => v.PostId == postId)
             .Where(voteExpression);
         
-        var candidateResults = await filteredVotes
-            .SelectMany(v => v.Votes)
-            .GroupBy(v => v.CandidateId)
-            .Select(g => new
-            {
-                Id = g.Key,
-                VoterAmount = g.Count(),
-                Score = g.Average(v => v.Value),
-            })
-            .ToDictionaryAsync(g => g.Id);
+        IQueryable<CandidateVote> candidateVotes = filteredVotes.SelectMany(v => v.Votes);
+        Dictionary<int, PollCandidateResultDto> candidateResults = await GetCandidateResultsAsync(candidateVotes);
 
         // Merge the results into the structure.
         foreach (PollCandidateResultDto candidateResult in resultDto.Polls.SelectMany(p => p.Candidates))
@@ -129,7 +121,9 @@ public class PostService(HiveMimeContext context)
             if (candidateResults.TryGetValue(candidateResult.Id, out var dbResult))
             {
                 candidateResult.VoterAmount = dbResult.VoterAmount;
-                candidateResult.Score = dbResult.Score;
+                candidateResult.AverageScore = dbResult.AverageScore;
+                candidateResult.MajorityVote = dbResult.MajorityVote;
+                candidateResult.MajorityRatio = dbResult.MajorityRatio;
             }
         }
 
@@ -384,5 +378,67 @@ public class PostService(HiveMimeContext context)
             if (!uniqueRanks.Contains(rank))
                 yield return $"Ranking poll is missing rank {rank}.";
         }
+    }
+
+    private async Task<Dictionary<int, PollCandidateResultDto>> GetCandidateResultsAsync(IQueryable<CandidateVote> candidateVotes)
+    {
+        // TODO: Split this over multiple DbContexts for parallelization.
+        
+        // Split up the aggregation per aggregation function type.
+        var countCandidates = await candidateVotes
+            .Where(v => v.Candidate.Poll.PollType == PollType.Choice)
+            .GroupBy(v => v.CandidateId)
+            .Select(g => new PollCandidateResultDto
+            {
+                Id = g.Key,
+                VoterAmount = g.Count()
+             })
+             .ToDictionaryAsync(g => g.Id);
+             
+        var averageCandidates = await candidateVotes
+            .Where(v => v.Candidate.Poll.PollType == PollType.Rank || v.Candidate.Poll.PollType == PollType.Score)
+            .GroupBy(v => v.CandidateId)
+            .Select(g => new PollCandidateResultDto
+            {
+                Id = g.Key,
+                VoterAmount = g.Count(),
+                AverageScore = g.Average(v => v.Value)
+             })
+             .ToDictionaryAsync(g => g.Id);
+
+        var majorityCandidates = await candidateVotes
+            .Where(v => v.Candidate.Poll.PollType == PollType.Category)
+            .GroupBy(v => v.CandidateId)
+            .Select(g => new
+            {
+                Id = g.Key,
+                Total = g.Count(),
+                // SQL is unable to drill down a grouping to get the majority. We need to fetch the distribution.
+                Distribution = g
+                    .GroupBy(x => x.Value)
+                    .Select(x => new { Value = x.Key, Count = x.Count() })
+            })
+            .ToListAsync()
+            .ContinueWith(t => t.Result.ToDictionary(x => x.Id, x =>
+            {
+                var majorityVote = x.Distribution.OrderByDescending(d => d.Count).First();
+                return new PollCandidateResultDto
+                {
+                    Id = x.Id,
+                    VoterAmount = x.Total,
+                    MajorityVote = majorityVote.Value,
+                    MajorityRatio = (double)majorityVote.Count / x.Total
+                };
+            }));
+        
+        var results = new Dictionary<int, PollCandidateResultDto>();
+
+        foreach (var task in new[] { countCandidates, averageCandidates, majorityCandidates })
+        {
+            foreach (var kvp in task)
+                results[kvp.Key] = kvp.Value;
+        }
+
+        return results;
     }
 }

--- a/src/Services/PostService.cs
+++ b/src/Services/PostService.cs
@@ -99,40 +99,43 @@ public class PostService(HiveMimeContext context)
     /// <param name="filter">The filter to apply to the post details.</param>
     public async Task<PostResultDto> GetPostResultAsync(int postId, string filter)
     {
+        // Fetch the results and DTO structure seperately for better performance.
+        PostResultDto resultDto = await context.Posts.Where(p => p.Id == postId)
+            .ProjectToType<PostResultDto>()
+            .FirstAsync();
+
         VoteQueryBase voteQuery = filter.ToVoteQuery();
         Expression<Func<PostVote, bool>> voteExpression = voteQuery.ToExpression();
 
-        // Fetch post and filtered votes seperately for better performance.
-        List<PostVote> filteredVotes = await context.PostVotes
-            .AsNoTracking()
+        IQueryable<PostVote> filteredVotes = context.PostVotes
             .Where(v => v.PostId == postId)
-            .Where(voteExpression)
-            .Include(v => v.User.Settings)
-            .Include(v => v.Votes)
-            .AsSplitQuery()
-            .ToListAsync();
+            .Where(voteExpression);
+        
+        var candidateResults = await filteredVotes
+            .SelectMany(v => v.Votes)
+            .GroupBy(v => v.CandidateId)
+            .Select(g => new
+            {
+                Id = g.Key,
+                VoterAmount = g.Count(),
+                Score = g.Average(v => v.Value),
+            })
+            .ToDictionaryAsync(g => g.Id);
 
-        Post post = await context.Posts
-            .AsNoTracking()
-            .Include(p => p.Polls.OrderBy(p => p.Id))
-                .ThenInclude(o => o.Candidates.OrderBy(c => c.Id))
-            .FirstAsync(p => p.Id == postId);
-
-        Dictionary<int, Candidate> candidateLookup = post.Polls
-            .SelectMany(p => p.Candidates)
-            .ToDictionary(c => c.Id);
-
-        // Add the filtered votes to the candidates.
-        candidateLookup.Values.ToList().ForEach(c => c.Votes = []);
-        foreach (CandidateVote vote in filteredVotes.SelectMany(v => v.Votes))
+        // Merge the results into the structure.
+        foreach (PollCandidateResultDto candidateResult in resultDto.Polls.SelectMany(p => p.Candidates))
         {
-            Candidate candidate = candidateLookup[vote.CandidateId];
-            candidate.Votes.Add(vote);
+            // Candidates unvoted for will remain default, that is okay.
+            if (candidateResults.TryGetValue(candidateResult.Id, out var dbResult))
+            {
+                candidateResult.VoterAmount = dbResult.VoterAmount;
+                candidateResult.Score = dbResult.Score;
+            }
         }
 
-        post.PostVotes = filteredVotes;
+        // TODO: Add auto polls at this point later.
 
-        return post.ToPostResultsDto();
+        return resultDto;
     }
 
     /// <summary>

--- a/src/Services/UserService.cs
+++ b/src/Services/UserService.cs
@@ -16,7 +16,7 @@ public class UserService(HiveMimeContext context, IConfiguration configuration, 
     public async Task<LoginDto> LoginAsync(string username)
     {
         // TODO: Add security measures / actual login.
-        User user = await context.Users.FirstOrDefaultAsync(u => u.Username == username) ?? await CreateUserAsync(username);
+        User user = await CreateUserAsync(username);
 
         Claim[] claims = [
             new Claim("UserId", user.Id.ToString())


### PR DESCRIPTION
Replaces logic in results fetching endpoint to aggregate as much as possible database-side.

- [ ] Bring back auto polls
- [x] Change aggregation logic depending on poll type (choice sum (or ratio), category majority vote, rest avg.)